### PR TITLE
Prevent RTL pane from showing when not active

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -8,7 +8,15 @@ export function register () {
     const channel = addons.getChannel()
     addons.addPanel(PANEL_ID, {
       title: 'RTL',
-      render: () => <RTLPanel channel={channel} api={api} />
+      render: props => {
+        const active = !props || props.active /* eslint-disable-line react/prop-types */
+
+        if (!active) {
+          return null
+        }
+
+        return (<RTLPanel channel={channel} api={api} />)
+      }
     })
   })
 }


### PR DESCRIPTION
I'm using your addon for a project and I noticed that the panel is showing when it's not active.

I hope this small fix can be merged in so I can continue using your wonderful package :-)

I'm simply checking if the addon is active before rendering the panel.

Note: I'm running Storybook v4.0.12 and the addon works fine besides this minor issue.

# Before
![rtl-before](https://user-images.githubusercontent.com/640976/49943491-56fba400-fee8-11e8-9655-a7f66c094665.gif)

# After
![rtl-after](https://user-images.githubusercontent.com/640976/49943498-59f69480-fee8-11e8-980a-6c5b1059143b.gif)
