### PR TITLE
Respect story parameters

### DIFF
--- a/.storybook/stories.js
+++ b/.storybook/stories.js
@@ -7,9 +7,15 @@ storiesOf('RTLToggle', module)
   .add('default', () => (
     <RTLToggle onChange={action('change')} />
   ))
-  .add('unchecked', () => (
-    <RTLToggle checked={false} onChange={action('change')} />
-  ))
+  .add(
+    'unchecked',
+    () => (<RTLToggle checked={false} onChange={action('change')} />)
+  )
+  .add(
+    'rtl parameter',
+    () => (<RTLToggle checked={false} onChange={action('change')} />),
+    { direction: 'rtl' }
+  )
   .add('checked', () => (
     <RTLToggle checked onChange={action('change')} />
   ))

--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ import { storiesOf } from '@storybook/react';
 import Component from './Component';
 
 storiesOf('Component', module)
-  .add('default', () => (
-    <Component />
-  ));
+  .add(
+    'default', 
+    () => ( <Component /> ),
+    // Optionally include direction as story parameter 
+    { direction: 'rtl' }
+  );
 ```
-
-**Note:** You can force a story to show in right-to-left mode by adding the query parameter `direction=rtl`.
 
 
 ## Meta

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
+        "@storybook/core-events": "^6.3.7",
         "prop-types": "^15.7.2",
         "styled-components": "^4.4.1"
       },
@@ -31,7 +32,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.3.1",
         "eslint-plugin-react": "^7.22.0",
-        "eslint-plugin-standard": "^5.0.0",
         "jest": "^26.6.3",
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
@@ -4316,6 +4316,19 @@
         }
       }
     },
+    "node_modules/@storybook/addon-actions/node_modules/@storybook/core-events": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/addons": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.3.0.tgz",
@@ -4338,6 +4351,18 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/addons/node_modules/@storybook/core-events": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/api": {
@@ -4373,6 +4398,18 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/core-events": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/builder-webpack4": {
@@ -4492,6 +4529,19 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@storybook/builder-webpack4/node_modules/@storybook/core-events": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/babel-plugin-macros": {
@@ -4792,6 +4842,19 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/channel-postmessage/node_modules/@storybook/core-events": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/channels": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.3.0.tgz",
@@ -4838,6 +4901,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/client-api/node_modules/@storybook/core-events": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/client-logger": {
@@ -4975,6 +5051,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@storybook/core-client/node_modules/@storybook/core-events": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/core-common": {
@@ -5269,9 +5358,9 @@
       }
     },
     "node_modules/@storybook/core-events": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
-      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.7.tgz",
+      "integrity": "sha512-l5Hlhe+C/dqxjobemZ6DWBhTOhQoFF3F1Y4kjFGE7pGZl/mas4M72I5I/FUcYCmbk2fbLfZX8hzKkUqS1hdyLA==",
       "dependencies": {
         "core-js": "^3.8.2"
       },
@@ -6339,6 +6428,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@storybook/ui/node_modules/@storybook/core-events": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/ui/node_modules/markdown-to-jsx": {
@@ -11772,30 +11874,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -30268,6 +30346,17 @@
         "ts-dedent": "^2.0.0",
         "util-deprecate": "^1.0.2",
         "uuid-browser": "^3.1.0"
+      },
+      "dependencies": {
+        "@storybook/core-events": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        }
       }
     },
     "@storybook/addons": {
@@ -30284,6 +30373,16 @@
         "core-js": "^3.8.2",
         "global": "^4.4.0",
         "regenerator-runtime": "^0.13.7"
+      },
+      "dependencies": {
+        "@storybook/core-events": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        }
       }
     },
     "@storybook/api": {
@@ -30311,6 +30410,16 @@
         "telejson": "^5.3.2",
         "ts-dedent": "^2.0.0",
         "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/core-events": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        }
       }
     },
     "@storybook/builder-webpack4": {
@@ -30413,6 +30522,15 @@
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
               "dev": true
             }
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
           }
         },
         "babel-plugin-macros": {
@@ -30634,6 +30752,17 @@
         "global": "^4.4.0",
         "qs": "^6.10.0",
         "telejson": "^5.3.2"
+      },
+      "dependencies": {
+        "@storybook/core-events": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        }
       }
     },
     "@storybook/channels": {
@@ -30670,6 +30799,17 @@
         "store2": "^2.12.0",
         "ts-dedent": "^2.0.0",
         "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/core-events": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        }
       }
     },
     "@storybook/client-logger": {
@@ -30763,6 +30903,17 @@
         "ts-dedent": "^2.0.0",
         "unfetch": "^4.2.0",
         "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/core-events": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        }
       }
     },
     "@storybook/core-common": {
@@ -30975,9 +31126,9 @@
       }
     },
     "@storybook/core-events": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
-      "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.7.tgz",
+      "integrity": "sha512-l5Hlhe+C/dqxjobemZ6DWBhTOhQoFF3F1Y4kjFGE7pGZl/mas4M72I5I/FUcYCmbk2fbLfZX8hzKkUqS1hdyLA==",
       "requires": {
         "core-js": "^3.8.2"
       }
@@ -31746,6 +31897,15 @@
         "store2": "^2.12.0"
       },
       "dependencies": {
+        "@storybook/core-events": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.3.0.tgz",
+          "integrity": "sha512-ZGTm5nQvFLlc2LVgoDyxo99MbQcFqQzkxIQReFkO7hPwwkcjcwmdBtnlmkn9/p5QQ5/8aU0k+ceCkrBNu1M83w==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
         "markdown-to-jsx": {
           "version": "6.11.4",
           "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
@@ -36287,13 +36447,6 @@
           }
         }
       }
-    },
-    "eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "dev": true,
-      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "storybook-addon-rtl",
   "description": "Right-to-left addon for Storybook.",
-  "author": {"name": "unindented"},
+  "author": {
+    "name": "unindented"
+  },
   "version": "0.3.1",
   "license": "MIT",
   "main": "dist/index.js",
@@ -21,7 +23,12 @@
   ],
   "storybook": {
     "displayName": "Storybook Addon RTL",
-    "supportedFrameworks": ["react", "vue", "angular", "web-components"]
+    "supportedFrameworks": [
+      "react",
+      "vue",
+      "angular",
+      "web-components"
+    ]
   },
   "scripts": {
     "clean:coverage": "rimraf coverage",
@@ -38,6 +45,7 @@
     "prepublishOnly": "run-s clean build"
   },
   "dependencies": {
+    "@storybook/core-events": "^6.3.7",
     "prop-types": "^15.7.2",
     "styled-components": "^4.4.1"
   },
@@ -61,7 +69,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.3.1",
     "eslint-plugin-react": "^7.22.0",
-    "eslint-plugin-standard": "^5.0.0",
     "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",
     "react": "^16.14.0",

--- a/src/containers/RTLPanel/__snapshots__/index.test.js.snap
+++ b/src/containers/RTLPanel/__snapshots__/index.test.js.snap
@@ -1,8 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RTLPanel with direction set while panel closed renders 1`] = `
+<RTLPanel
+  checked={true}
+  onChange={[Function]}
+/>
+`;
+
 exports[`RTLPanel with query parameter renders 1`] = `
 <RTLPanel
   checked={true}
+  onChange={[Function]}
+/>
+`;
+
+exports[`RTLPanel with story param renders 1`] = `
+<RTLPanel
+  checked={true}
+  onChange={[Function]}
+/>
+`;
+
+exports[`RTLPanel with story param responds to changes 1`] = `
+<RTLPanel
+  checked={true}
+  onChange={[Function]}
+/>
+`;
+
+exports[`RTLPanel with story param responds to changes 2`] = `
+<RTLPanel
+  checked={false}
   onChange={[Function]}
 />
 `;

--- a/src/containers/RTLPanel/index.test.js
+++ b/src/containers/RTLPanel/index.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow, configure } from 'enzyme'
 import RTLPanel from '.'
 import Adapter from 'enzyme-adapter-react-16'
+import { UPDATE_EVENT_ID } from '../../constants'
 
 configure({ adapter: new Adapter() })
 
@@ -16,6 +17,7 @@ describe('RTLPanel', () => {
     }
     channel = {
       on: jest.fn(),
+      last: jest.fn(),
       removeListener: jest.fn(),
       emit: jest.fn()
     }
@@ -39,6 +41,46 @@ describe('RTLPanel', () => {
     })
 
     it('renders', () => {
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('with direction set while panel closed', () => {
+    beforeEach(() => {
+      channel.last.mockReturnValue([{ direction: 'rtl' }])
+      wrapper = shallow(<RTLPanel api={api} channel={channel} />)
+    })
+
+    it('renders', () => {
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  // Simulate a story param by emitting an event after the component is created
+  describe('with story param', () => {
+    let updateEventHandler = () => {}
+
+    beforeEach(() => {
+      api.getQueryParam.mockReturnValue('rtl')
+      channel.on.mockImplementation((eventID, handler) => {
+        if (eventID === UPDATE_EVENT_ID) {
+          updateEventHandler = handler
+        }
+      })
+      wrapper = shallow(<RTLPanel api={api} channel={channel} />)
+    })
+
+    it('renders', () => {
+      updateEventHandler({ direction: 'rtl' })
+
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('responds to changes', () => {
+      updateEventHandler({ direction: 'rtl' })
+      expect(wrapper).toMatchSnapshot()
+
+      updateEventHandler({ direction: 'ltr' })
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/manager.js
+++ b/src/manager.js
@@ -1,11 +1,15 @@
 import React from 'react'
 import addons from '@storybook/addons'
+import { STORY_RENDERED } from '@storybook/core-events'
 import RTLPanel from './containers/RTLPanel'
-import { ADDON_ID, PANEL_ID } from './constants'
+import { ADDON_ID, PANEL_ID, UPDATE_EVENT_ID } from './constants'
+import { getDefaultTextDirection } from './utils'
 
 export function register () {
   addons.register(ADDON_ID, (api) => {
     const channel = addons.getChannel()
+    setDirectionOnStoryChange(api)
+
     addons.addPanel(PANEL_ID, {
       title: 'RTL',
       render: ({ active, key }) => { /* eslint-disable-line react/prop-types, react/display-name */
@@ -16,5 +20,31 @@ export function register () {
         return (<RTLPanel key={key} channel={channel} api={api} />)
       }
     })
+  })
+}
+
+export function setDirectionOnStoryChange (api) {
+  const channel = addons.getChannel()
+
+  // Keep track of the most recent value that was a result of user interaction
+  // so we can return to this value whenever a story is opened that does not have a parameter
+  let lastUserInteractionValue
+  // Whenever a story is rendered, update the state to represent the parameter value of the story.
+  // We do this here and not in the panel component because we want the parameter to be respected
+  // even if the panel is never opened
+  channel.on(STORY_RENDERED, (_) => {
+    const lastUpdate = channel.last(UPDATE_EVENT_ID)?.[0]
+    lastUserInteractionValue = lastUpdate.userInteraction ? lastUpdate.direction : lastUserInteractionValue
+
+    const paramValue = api.getCurrentParameter('direction')
+    let newDirection
+    if (paramValue) {
+      newDirection = paramValue
+    } else if (lastUserInteractionValue) {
+      newDirection = lastUserInteractionValue
+    } else {
+      newDirection = getDefaultTextDirection(api)
+    }
+    channel.emit(UPDATE_EVENT_ID, { direction: newDirection, userInteraction: false })
   })
 }

--- a/src/manager.test.js
+++ b/src/manager.test.js
@@ -1,0 +1,67 @@
+import addons, { mockChannel } from '@storybook/addons'
+import { STORY_RENDERED } from '@storybook/core-events'
+import { UPDATE_EVENT_ID } from './constants'
+import { setDirectionOnStoryChange } from './manager'
+
+describe('setDirectionByParameters', () => {
+  const updateHandler = jest.fn()
+  const api = {
+    getCurrentParameter: jest.fn(),
+    getQueryParam: jest.fn()
+  }
+  let channel
+
+  beforeEach(() => {
+    updateHandler.mockReset()
+    addons.setChannel(mockChannel())
+    channel = addons.getChannel()
+    channel.on(UPDATE_EVENT_ID, updateHandler)
+    channel.emit(UPDATE_EVENT_ID, { direction: 'ltr' })
+    setDirectionOnStoryChange(api)
+  })
+
+  it('emits story parameter when story is rendered', () => {
+    api.getCurrentParameter.mockReturnValue('rtl')
+
+    channel.emit(STORY_RENDERED)
+    expect(updateHandler).toHaveBeenLastCalledWith({ direction: 'rtl', userInteraction: false })
+  })
+
+  it('emits last user interaction when story is rendered without parameters', () => {
+    api.getCurrentParameter.mockReturnValue(undefined)
+    channel.emit(UPDATE_EVENT_ID, { direction: 'ltr', userInteraction: true })
+
+    channel.emit(STORY_RENDERED)
+    expect(updateHandler).toHaveBeenLastCalledWith({ direction: 'ltr', userInteraction: false })
+  })
+
+  it('emits story parameter even if there was previous user interaction', () => {
+    channel.emit(UPDATE_EVENT_ID, { direction: 'ltr', userInteraction: true })
+    api.getCurrentParameter.mockReturnValue('rtl')
+
+    channel.emit(STORY_RENDERED)
+    expect(updateHandler).toHaveBeenLastCalledWith({ direction: 'rtl', userInteraction: false })
+  })
+
+  it('emits last user interaction when switching from parameter story to non-parameter story', () => {
+    channel.emit(UPDATE_EVENT_ID, { direction: 'ltr', userInteraction: true })
+    api.getCurrentParameter.mockReturnValue('rtl')
+    channel.emit(STORY_RENDERED)
+
+    api.getCurrentParameter.mockReturnValue(undefined)
+    channel.emit(STORY_RENDERED)
+
+    expect(updateHandler).toHaveBeenLastCalledWith({ direction: 'ltr', userInteraction: false })
+  })
+
+  it('emits default direction when switching from parameter story to non-parameter story', () => {
+    api.getCurrentParameter.mockReturnValue('rtl')
+    channel.emit(STORY_RENDERED)
+    expect(updateHandler).toHaveBeenLastCalledWith({ direction: 'rtl', userInteraction: false })
+
+    api.getCurrentParameter.mockReturnValue(undefined)
+    channel.emit(STORY_RENDERED)
+
+    expect(updateHandler).toHaveBeenLastCalledWith({ direction: 'ltr', userInteraction: false })
+  })
+})


### PR DESCRIPTION
Story parameters should now be respected. Switching to a story that has a direction parameter present will cause the direction to be set. If the panel is open, the toggle will always update to reflect the current direction.

One down-side of this is that if you want to see how all of your stories behave in RTL, and if you include the direction parameter in your stories, the value of the toggle will switch whenever you switch stories. I think this is expected.

Because we want the parameter to be respected even if the panel isn't open, I moved some of the logic out of the component and into the `manager.js` file. The "source of truth" for the direction is now the most recent direction event emitted (which can happen when a story is opened that has a parameter, or when the toggle in the addon is changed).

Closes #16