### PR TITLE
Correctly register

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "storybook-addon-rtl",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@storybook/core-events": "^6.3.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "unindented"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "main": "dist/index.js",
   "repository": {

--- a/preset.js
+++ b/preset.js
@@ -1,6 +1,6 @@
 // This file is required for the Storybook Addon Catalog.
 function managerEntries (entry = []) {
-  return [...entry, require.resolve('./dist/manager')]
+  return [...entry, require.resolve('./register')]
 }
 
 module.exports = { managerEntries }


### PR DESCRIPTION
When trying to use the managerEntries format, I messed up and didn't do it right. This should return the behavior to how it was before: users can add 'storybook-addon-rtl' to their addons array and it will work.